### PR TITLE
Fix `BiometricManager.authenticate` typing

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -410,7 +410,7 @@ export type BiometricManager = {
   ) => BiometricManager;
   authenticate: (
     params: BiometricAuthenticateParams,
-    callback?: (isAuthenticated: boolean) => unknown
+    callback?: (isAuthenticated: boolean; token?: string) => unknown
   ) => BiometricManager;
   updateBiometricToken: (
     token: string,


### PR DESCRIPTION
The second parameter was missing from the typing of the `authenticate` method.

https://core.telegram.org/bots/webapps#biometricmanager:~:text=If%20so%2C%20the%20second%20argument%20will%20be%20a%20biometric%20token.